### PR TITLE
[fix]: 22-correct-ta-name

### DIFF
--- a/src/tofix/classdata.json
+++ b/src/tofix/classdata.json
@@ -1,4 +1,4 @@
 {
     "classname": "BUAASE2025",
-    "teacher": "Prof. WuJi"
+    "teacher": "Prof. Luojie, Prof.Renjian"
 }


### PR DESCRIPTION
This PR corrects the spelling of the TA’s name in classdata.json.

fix #22  